### PR TITLE
Add support for registering callbacks between plug-ins

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -16,7 +16,8 @@ EXTRA_DIST = \
 	ctfOverseer.def \
 	ctfOverseer.sln \
 	ctfOverseer.vcxproj \
-	ctfOverseer.vcxproj.filters
+	ctfOverseer.vcxproj.filters \
+	ctfOverseerExtension.cpp
 
 MAINTAINERCLEANFILES =	\
 	Makefile.in

--- a/ctfOverseer.cpp
+++ b/ctfOverseer.cpp
@@ -22,6 +22,9 @@
 
 #include <functional>
 #include <map>
+#include <utility>
+
+#include "ctfOverseerAPI.h"
 
 #include "bzfsAPI.h"
 #include "plugin_utils.h"
@@ -42,8 +45,6 @@ const int MESSAGE_SPAM_INTERVAL = 5; /// The number of seconds between a message
 const int VERBOSE_DEBUG_LEVEL = 4; /// The debug level that verbose messages will be written out at
 
 typedef std::map<std::string, std::string> StringDict;
-typedef std::pair<bz_eTeamType, bz_eTeamType> TeamPair;
-typedef std::function<void(int playerID, bool isUnfair, bool wasDisallowed, bool isSelfCap)> OnCaptureEventCallbackV1;
 
 struct Configuration
 {

--- a/ctfOverseer.cpp
+++ b/ctfOverseer.cpp
@@ -33,7 +33,7 @@ const std::string PLUGIN_NAME = "CTF Overseer";
 const int MAJOR = 1;
 const int MINOR = 1;
 const int REV = 2;
-const int BUILD = 33;
+const int BUILD = 34;
 
 // Plugin settings
 const int RECALC_INTERVAL = 20; /// The number of seconds between a flag drop and point bonus point recalculation
@@ -43,7 +43,7 @@ const int VERBOSE_DEBUG_LEVEL = 4; /// The debug level that verbose messages wil
 
 typedef std::map<std::string, std::string> StringDict;
 typedef std::pair<bz_eTeamType, bz_eTeamType> TeamPair;
-typedef std::function<void(int playerID, bool isUnfair, bool wasDisallowed)> OnCaptureEventCallbackV1;
+typedef std::function<void(int playerID, bool isUnfair, bool wasDisallowed, bool isSelfCap)> OnCaptureEventCallbackV1;
 
 struct Configuration
 {
@@ -110,6 +110,7 @@ const char* CTFOverseer::Name()
 
 void CTFOverseer::Init(const char* config)
 {
+    onCaptureEventListenersCounter = 0;
     configFile = config;
 
     loadConfigurationFile();
@@ -225,7 +226,7 @@ void CTFOverseer::Event(bz_EventData* eventData)
 
             for (auto cb : onCaptureEventListeners)
             {
-                cb.second(data->playerCapping, isUnfairCap, areUnfairCapsDisabled);
+                cb.second(data->playerCapping, isUnfairCap, areUnfairCapsDisabled, isSelfCap);
             }
         }
         break;

--- a/ctfOverseerAPI.h
+++ b/ctfOverseerAPI.h
@@ -1,0 +1,32 @@
+#ifndef CTFOVERSEER_API_H
+#define CTFOVERSEER_API_H
+
+#include <functional>
+#include <utility>
+
+#include "bzfsAPI.h"
+
+/**
+ * The pairing of bz_eTeamType values used. The first value of the pair is the team that is grabbing or capturing the
+ * enemy flag. The second value is the team whose flag is being stolen or captured.
+ *
+ * @since 1.1.2
+ */
+typedef std::pair<bz_eTeamType, bz_eTeamType> TeamPair;
+
+/**
+ * Function signature used for the "on capture" callback that's called by CTF Overseer.
+ *
+ * The "on capture" event triggered by CTF Overseer is different than BZFlag's official bz_eCaptureEvent in that in this
+ * callback, information regarding self-capture, unfairness, and disallowing flag captures.
+ *
+ * @arg playerID - The playerID of the player who triggered the capping event
+ * @arg isUnfair - Whether or not the capture event was considered "fair"
+ * @arg wasDisallowed - Whether or not the capture event was disallowed because it was unfair or a self-capture
+ * @arg isSelfCap - Whether or not the capture event was triggered by a self-capture
+ *
+ * @since 1.1.2
+ */
+typedef std::function<void(int playerID, bool isUnfair, bool wasDisallowed, bool isSelfCap)> OnCaptureEventCallbackV1;
+
+#endif

--- a/ctfOverseerExtension.cpp
+++ b/ctfOverseerExtension.cpp
@@ -1,0 +1,50 @@
+#include <functional>
+
+#include "bzfsAPI.h"
+
+class SamplePlugin : public bz_Plugin
+{
+public:
+    virtual const char* Name();
+    virtual void Init(const char* config);
+    virtual void Cleanup();
+    virtual void Event(bz_EventData* eventData) {};
+
+private:
+    int onCaptureEventListenerID;
+    void OnCaptureEventCallbackV1(int playerID, bool isUnfair, bool wasDisallowed, bool isSelfCap);
+};
+
+BZ_PLUGIN(SamplePlugin)
+
+const char* SamplePlugin::Name()
+{
+    return "ctfOverseer Sample Callback Plugin";
+}
+
+void SamplePlugin::Init(const char* config)
+{
+    using namespace std::placeholders;
+
+    std::string ctfOverseer = bz_getclipFieldString("allejo/ctfOverseer");
+    std::function<void(int, bool, bool, bool)> callback = std::bind(&SamplePlugin::OnCaptureEventCallbackV1, this, _1, _2, _3, _4);
+    onCaptureEventListenerID = bz_callPluginGenericCallback(ctfOverseer.c_str(), "listenOnCaptureV1", static_cast<void*>(&callback));
+
+    bz_debugMessagef(0, "Event Listener registered: %d", onCaptureEventListenerID);
+}
+
+void SamplePlugin::Cleanup()
+{
+    Flush();
+
+    std::string ctfOverseer = bz_getclipFieldString("allejo/ctfOverseer");
+    bz_callPluginGenericCallback(ctfOverseer.c_str(), "removeOnCapture", static_cast<int*>(&onCaptureEventListenerID));
+}
+
+void SamplePlugin::OnCaptureEventCallbackV1(int playerID, bool isUnfair, bool wasDisallowed, bool isSelfCap)
+{
+    bz_debugMessagef(0, "Player Capping: %d", playerID);
+    bz_debugMessagef(0, "Was Unfair?: %s", isUnfair ? "true" : "false");
+    bz_debugMessagef(0, "Was Disallowed: %s", wasDisallowed ? "true" : "false");
+    bz_debugMessagef(0, "Was Self-cap: %s", isSelfCap ? "true" : "false");
+}

--- a/ctfOverseerExtension.cpp
+++ b/ctfOverseerExtension.cpp
@@ -1,5 +1,6 @@
 #include <functional>
 
+#include "ctfOverseerAPI.h"
 #include "bzfsAPI.h"
 
 class SamplePlugin : public bz_Plugin
@@ -27,7 +28,7 @@ void SamplePlugin::Init(const char* config)
     using namespace std::placeholders;
 
     std::string ctfOverseer = bz_getclipFieldString("allejo/ctfOverseer");
-    std::function<void(int, bool, bool, bool)> callback = std::bind(&SamplePlugin::OnCaptureEventCallbackV1, this, _1, _2, _3, _4);
+    OnCaptureEventCallbackV1 callback = std::bind(&SamplePlugin::OnCaptureEventCallbackV1, this, _1, _2, _3, _4);
     onCaptureEventListenerID = bz_callPluginGenericCallback(ctfOverseer.c_str(), "listenOnCaptureV1", static_cast<void*>(&callback));
 
     bz_debugMessagef(0, "Event Listener registered: %d", onCaptureEventListenerID);

--- a/ctfOverseerExtension.cpp
+++ b/ctfOverseerExtension.cpp
@@ -13,7 +13,11 @@ public:
 
 private:
     int onCaptureEventListenerID;
-    void OnCaptureEventCallbackV1(int playerID, bool isUnfair, bool wasDisallowed, bool isSelfCap);
+    void OnCaptureEventCallback(int playerID, bool isUnfair, bool wasDisallowed, bool isSelfCap);
+
+    const char* getCTFOverseerPlugin();
+    void registerCTFOverseerCallback();
+    void removeCTFOverseerCallback();
 };
 
 BZ_PLUGIN(SamplePlugin)
@@ -25,24 +29,62 @@ const char* SamplePlugin::Name()
 
 void SamplePlugin::Init(const char* config)
 {
-    using namespace std::placeholders;
-
-    std::string ctfOverseer = bz_getclipFieldString("allejo/ctfOverseer");
-    OnCaptureEventCallbackV1 callback = std::bind(&SamplePlugin::OnCaptureEventCallbackV1, this, _1, _2, _3, _4);
-    onCaptureEventListenerID = bz_callPluginGenericCallback(ctfOverseer.c_str(), "listenOnCaptureV1", static_cast<void*>(&callback));
-
-    bz_debugMessagef(0, "Event Listener registered: %d", onCaptureEventListenerID);
+    registerCTFOverseerCallback();
 }
 
 void SamplePlugin::Cleanup()
 {
     Flush();
 
-    std::string ctfOverseer = bz_getclipFieldString("allejo/ctfOverseer");
-    bz_callPluginGenericCallback(ctfOverseer.c_str(), "removeOnCapture", static_cast<int*>(&onCaptureEventListenerID));
+    removeCTFOverseerCallback();
 }
 
-void SamplePlugin::OnCaptureEventCallbackV1(int playerID, bool isUnfair, bool wasDisallowed, bool isSelfCap)
+const char* SamplePlugin::getCTFOverseerPlugin()
+{
+    const char* pluginName = bz_getclipFieldString("allejo/ctfOverseer");
+
+    if (pluginName == NULL)
+    {
+        bz_debugMessage(0, "ERROR! The plug-in for allejo/ctfOverseer could not be found.");
+    }
+    else if (!bz_pluginExists(pluginName))
+    {
+        bz_debugMessage(0, "ERROR! The required CTFOverseer plug-in is not loaded. Be sure it is loaded before this plug-in.");
+    }
+
+    return pluginName;
+}
+
+void SamplePlugin::registerCTFOverseerCallback()
+{
+    using namespace std::placeholders;
+
+    const char* ctfOverseer = getCTFOverseerPlugin();
+
+    if (ctfOverseer == NULL)
+    {
+        return;
+    }
+
+    OnCaptureEventCallbackV1 callback = std::bind(&SamplePlugin::OnCaptureEventCallback, this, _1, _2, _3, _4);
+    onCaptureEventListenerID = bz_callPluginGenericCallback(ctfOverseer, "listenOnCaptureV1", static_cast<void*>(&callback));
+
+    bz_debugMessagef(0, "Event Listener registered with ID: %d", onCaptureEventListenerID);
+}
+
+void SamplePlugin::removeCTFOverseerCallback()
+{
+    const char* ctfOverseer = getCTFOverseerPlugin();
+
+    if (ctfOverseer == NULL)
+    {
+        return;
+    }
+
+    bz_callPluginGenericCallback(ctfOverseer, "removeOnCapture", static_cast<int*>(&onCaptureEventListenerID));
+}
+
+void SamplePlugin::OnCaptureEventCallback(int playerID, bool isUnfair, bool wasDisallowed, bool isSelfCap)
 {
     bz_debugMessagef(0, "Player Capping: %d", playerID);
     bz_debugMessagef(0, "Was Unfair?: %s", isUnfair ? "true" : "false");


### PR DESCRIPTION
This PR introduces an `OnCaptureEventCallbackV1` callback function signature that can be used for external plug-ins to listen for when "events" are triggered by this plug-in.

I was wondering if either @Jeffm2501 or @jwmelto were free to give me any feedback/direction in this design?